### PR TITLE
Fix Trying to access array offset on value of type null

### DIFF
--- a/lib/Horde/Idna.php
+++ b/lib/Horde/Idna.php
@@ -88,6 +88,9 @@ class Horde_Idna
      */
     protected static function _checkForError($info)
     {
+        if (!isset($info['errors'])) {
+            return;
+        }
         switch (true) {
         case $info['errors'] & IDNA_ERROR_EMPTY_LABEL:
             throw new Horde_Idna_Exception(Horde_Idna_Translation::t(


### PR DESCRIPTION
With 7.4.0RC4

Encounter during **Horde_Kolab_Storage** test suite:

```
1) Horde_Kolab_Storage_ComponentTest_Data_Object_Message_ModifiedTest::testStore
Trying to access array offset on value of type null
/usr/share/pear/Horde/Idna.php:92
/usr/share/pear/Horde/Idna.php:43
/usr/share/pear/Horde/Mail/Rfc822/Address.php:139
/usr/share/pear/Horde/Mail/Rfc822/Address.php:166
/usr/share/pear/Horde/Mail/Rfc822/Object.php:67
/usr/share/pear/Horde/Mail/Rfc822/List.php:238
/usr/share/pear/Horde/Mail/Rfc822/Object.php:67
/usr/share/pear/Horde/Mime/Headers/Addresses.php:169
/usr/share/pear/Horde/Mime/Headers/Addresses.php:134
/usr/share/pear/Horde/Mime/Headers/Element.php:101
/usr/share/pear/Horde/Mime/Headers.php:132
/usr/share/pear/Horde/Mime/Headers.php:173
/usr/share/pear/Horde/Mime/Part.php:1091
/builddir/build/BUILD/php-horde-Horde-Kolab-Storage-2.2.3/Horde_Kolab_Storage-2.2.3/lib/Horde/Kolab/Storage/Object.php:486
/builddir/build/BUILD/php-horde-Horde-Kolab-Storage-2.2.3/Horde_Kolab_Storage-2.2.3/lib/Horde/Kolab/Storage/Object.php:462
/builddir/build/BUILD/php-horde-Horde-Kolab-Storage-2.2.3/Horde_Kolab_Storage-2.2.3/test/Horde/Kolab/Storage/ComponentTest/Data/Object/Message/ModifiedTest.php:55

```