### PR TITLE
Fix encoding null with PHP8.1

### DIFF
--- a/lib/Horde/Idna.php
+++ b/lib/Horde/Idna.php
@@ -36,9 +36,15 @@ class Horde_Idna
     {
         switch ($backend = static::_getBackend()) {
         case 'INTL':
+            if ($data === null) {
+                return false;
+            }
             return idn_to_ascii($data);
 
         case 'INTL_UTS46':
+            if ($data === null) {
+                return false;
+            }
             $result = idn_to_ascii($data, 0, INTL_IDNA_VARIANT_UTS46, $info);
             self::_checkForError($info);
             return $result;


### PR DESCRIPTION
Fixes

> PHP Deprecated:  idn_to_ascii(): Passing null to parameter #1 ($domain) of type string is deprecated in vendor/bytestream/horde-idna/lib/Horde/Idna.php on line 42

Ref https://3v4l.org/uK0hN